### PR TITLE
Fix MRKL agent docs

### DIFF
--- a/docs/modules/agents/agents/examples/mrkl.ipynb
+++ b/docs/modules/agents/agents/examples/mrkl.ipynb
@@ -2,17 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f1390152",
+   "id": "57906c6a",
    "metadata": {},
    "source": [
     "# MRKL\n",
     "\n",
-    "This notebook showcases using an agent to replicate the MRKL chain."
+    "This notebook showcases using an agent to replicate the MRKL chain.  The MRKL chain definition can be found in langchain/agents/mrkl."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "39ea3638",
+   "id": "f9c33f35",
    "metadata": {},
    "source": [
     "This uses the example Chinook database.\n",
@@ -21,60 +21,75 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "ac561cc4",
+   "execution_count": null,
+   "id": "526b40f7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain import LLMMathChain, OpenAI, SerpAPIWrapper, SQLDatabase, SQLDatabaseChain\n",
-    "from langchain.agents import initialize_agent, Tool"
+    "import os\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"\"\n",
+    "os.environ[\"SERPAPI_API_KEY\"] = \"\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "07e96d99",
+   "execution_count": null,
+   "id": "ae3268e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! pip install langchain==0.0.16 openai google-search-results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1418f8f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain import LLMMathChain, OpenAI, SerpAPIChain, MRKLChain\n",
+    "from langchain.agents.mrkl.base import ChainConfig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06ecbf30",
    "metadata": {},
    "outputs": [],
    "source": [
     "llm = OpenAI(temperature=0)\n",
-    "search = SerpAPIWrapper()\n",
+    "search = SerpAPIChain()\n",
     "llm_math_chain = LLMMathChain(llm=llm, verbose=True)\n",
-    "db = SQLDatabase.from_uri(\"sqlite:///../../../../notebooks/Chinook.db\")\n",
-    "db_chain = SQLDatabaseChain(llm=llm, database=db, verbose=True)\n",
-    "tools = [\n",
-    "    Tool(\n",
-    "        name = \"Search\",\n",
-    "        func=search.run,\n",
-    "        description=\"useful for when you need to answer questions about current events. You should ask targeted questions\"\n",
+    "chains = [\n",
+    "    ChainConfig(\n",
+    "        action_name = \"Search\",\n",
+    "        action=search.run,\n",
+    "        action_description=\"useful for when you need to answer questions about current events\"\n",
     "    ),\n",
-    "    Tool(\n",
-    "        name=\"Calculator\",\n",
-    "        func=llm_math_chain.run,\n",
-    "        description=\"useful for when you need to answer questions about math\"\n",
+    "    ChainConfig(\n",
+    "        action_name=\"Calculator\",\n",
+    "        action=llm_math_chain.run,\n",
+    "        action_description=\"useful for when you need to answer questions about math\"\n",
     "    ),\n",
-    "    Tool(\n",
-    "        name=\"FooBar DB\",\n",
-    "        func=db_chain.run,\n",
-    "        description=\"useful for when you need to answer questions about FooBar. Input should be in the form of a question containing full context\"\n",
-    "    )\n",
     "]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "a069c4b6",
+   "execution_count": null,
+   "id": "68855a49",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mrkl = initialize_agent(tools, llm, agent=\"zero-shot-react-description\", verbose=True)"
+    "mrkl = MRKLChain.from_chains(llm, chains, verbose=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "e603cd7d",
+   "execution_count": null,
+   "id": "881f242b",
    "metadata": {},
    "outputs": [
     {
@@ -121,9 +136,8 @@
        "'Camila Morrone is 25 years old and her age raised to the 0.43 power is 3.991298452658078.'"
       ]
      },
-     "execution_count": 4,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -132,8 +146,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "a5c07010",
+   "execution_count": null,
+   "id": "12e93c08",
    "metadata": {},
    "outputs": [
     {
@@ -171,9 +185,8 @@
        "'The artist who released the album The Storm Before the Calm is Alanis Morissette and the albums of theirs in the FooBar database are Jagged Little Pill.'"
       ]
      },
-     "execution_count": 5,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -183,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af016a70",
+   "id": "4d19ad74",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
The current MRKL docs don't use the existing MRKL chain definition.  This PR updates the doc to use `mrkl = MRKLChain.from_chains(llm, chains, verbose=True)` instead of the original `zero-shot-react-description` agent (which isn't a MRKL agent).