### PR TITLE
Fix typo `pandocs` to `pandoc`

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/epub.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/epub.ipynb
@@ -9,7 +9,7 @@
     "\n",
     ">[EPUB](https://en.wikipedia.org/wiki/EPUB) is an e-book file format that uses the \".epub\" file extension. The term is short for electronic publication and is sometimes styled ePub. `EPUB` is supported by many e-readers, and compatible software is available for most smartphones, tablets, and computers.\n",
     "\n",
-    "This covers how to load `.epub` documents into the Document format that we can use downstream. You'll need to install the [`pandocs`](https://pandoc.org/installing.html) package for this loader to work."
+    "This covers how to load `.epub` documents into the Document format that we can use downstream. You'll need to install the [`pandoc`](https://pandoc.org/installing.html) package for this loader to work."
    ]
   },
   {
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#!pip install pandocs"
+    "#!pip install pandoc"
    ]
   },
   {


### PR DESCRIPTION
Fixes https://github.com/hwchase17/langchain/issues/6204

### Context

An typo issue with `pandoc`.

#### Who can review?
@hwchase17
